### PR TITLE
Added frame capture functionality to control 

### DIFF
--- a/Unosquare.FFmpegMediaElement.Tests/MainWindow.xaml
+++ b/Unosquare.FFmpegMediaElement.Tests/MainWindow.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="Unosquare.FFmpegMediaElement.Tests.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="{Binding ElementName=MediaEl, Path=Source}" Height="480" Width="640" 
+        Title="{Binding ElementName=MediaEl, Path=Source}" Height="484" Width="640" 
         xmlns:ffme="clr-namespace:Unosquare.FFmpegMediaElement;assembly=Unosquare.FFmpegMediaElement">
     <Grid>
         <Grid.RowDefinitions>
@@ -43,6 +43,7 @@
             <DockPanel LastChildFill="True">
                 <Label>Synchronous Scrubbing Enabled:</Label>
                 <CheckBox IsChecked="{Binding ElementName=MediaEl, Path=ScrubbingEnabled}" VerticalAlignment="Center" />
+                <Button Width="70" Click="Button_Click_1">Save Frame</Button>
             </DockPanel>
         </StackPanel>
 

--- a/Unosquare.FFmpegMediaElement.Tests/MainWindow.xaml.cs
+++ b/Unosquare.FFmpegMediaElement.Tests/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -96,5 +97,25 @@ namespace Unosquare.FFmpegMediaElement.Tests
             }
         }
 
+        private void Button_Click_1(object sender, RoutedEventArgs e)
+        {
+            Microsoft.Win32.SaveFileDialog saveDlg = new Microsoft.Win32.SaveFileDialog();
+            saveDlg.Filter = "Bitmap (*.bmp)|*.bmp";
+            saveDlg.DefaultExt = "bmp";
+            saveDlg.AddExtension = true;
+
+            Nullable<bool> result = saveDlg.ShowDialog();
+
+            if (result == true)
+            {
+                using (FileStream fileStream = new FileStream(saveDlg.FileName, FileMode.OpenOrCreate))
+                {
+                    PngBitmapEncoder encoder = new PngBitmapEncoder();
+                    WriteableBitmap wBMP = MediaEl.GetCurrentFrame();
+                    encoder.Frames.Add(BitmapFrame.Create(wBMP));
+                    encoder.Save(fileStream);
+                }
+            }
+        }
     }
 }

--- a/Unosquare.FFmpegMediaElement/MediaElement.cs
+++ b/Unosquare.FFmpegMediaElement/MediaElement.cs
@@ -48,7 +48,14 @@
             }
         }
 
-
+        /// <summary>
+        /// Gets the current frame being displayed
+        /// </summary>
+        /// <returns>Clone of the current frame</returns>
+        public WriteableBitmap GetCurrentFrame()
+        {
+            return TargetBitmap.Clone();
+        }
         #endregion
 
         #region FFmpeg Paths


### PR DESCRIPTION
Added frame capture functionality to control by returning a clone of the WriteableBitmap used for the displayed frame. Added functionality to test application by adding a save button that captures the current frame and saves it to a bitmap file.