### PR TITLE
Backing field for ManualResetEvents prevent synchronization problem o…

### DIFF
--- a/Unosquare.FFME/Commands/OpenCommand.cs
+++ b/Unosquare.FFME/Commands/OpenCommand.cs
@@ -74,10 +74,10 @@
                 m.IsTaskCancellationPending = false;
 
                 // Set the initial state of the task cycles.
-                m.SeekingDone.Set();
-                m.BlockRenderingCycle.Reset();
-                m.FrameDecodingCycle.Reset();
-                m.PacketReadingCycle.Reset();
+                m.SeekingDone?.Set();
+                m.BlockRenderingCycle?.Reset();
+                m.FrameDecodingCycle?.Reset();
+                m.PacketReadingCycle?.Reset();
 
                 // Create the thread runners
                 m.PacketReadingTask = new Thread(m.RunPacketReadingWorker)

--- a/Unosquare.FFME/Commands/SeekCommand.cs
+++ b/Unosquare.FFME/Commands/SeekCommand.cs
@@ -45,7 +45,7 @@
             pause.ExecuteInternal();
 
             var initialPosition = m.Clock.Position;
-            m.SeekingDone.Reset();
+            m.SeekingDone?.Reset();
             var startTime = DateTime.UtcNow;
 
             try
@@ -68,7 +68,7 @@
                 // wait for the current reading and decoding cycles
                 // to finish. We don't want to interfere with reading in progress
                 // or decoding in progress
-                m.PacketReadingCycle.WaitOne();
+                m.PacketReadingCycle?.WaitOne();
 
                 // Capture seek target adjustment
                 var adjustedSeekTarget = TargetPosition;
@@ -164,7 +164,7 @@
                         $"SEEK D: Elapsed: {startTime.FormatElapsed()} | Target: {TargetPosition.Format()}");
                 }
 
-                m.SeekingDone.Set();
+                m.SeekingDone?.Set();
 
                 if (WasPlaying)
                 {

--- a/Unosquare.FFME/MediaElement.cs
+++ b/Unosquare.FFME/MediaElement.cs
@@ -71,6 +71,11 @@
         /// </summary>
         private AtomicBoolean m_IsPositionUpdating = new AtomicBoolean();
 
+        /// <summary>
+        /// Flag when disposing process start but not finished yet
+        /// </summary>
+        private AtomicBoolean m_IsDisposing = new AtomicBoolean();
+
 #pragma warning restore SA1401 // Fields must be private
         #endregion
 
@@ -372,6 +377,7 @@
 
             if (alsoManaged)
             {
+                m_IsDisposing.Value = true;
                 // free managed resources
                 Commands.Close();
 
@@ -388,10 +394,10 @@
                     UIPropertyUpdateTimer = null;
                 }
 
-                PacketReadingCycle.Dispose();
-                FrameDecodingCycle.Dispose();
-                BlockRenderingCycle.Dispose();
-                SeekingDone.Dispose();
+                m_PacketReadingCycle.Dispose();
+                m_FrameDecodingCycle.Dispose();
+                m_BlockRenderingCycle.Dispose();
+                m_SeekingDone.Dispose();
             }
 
             IsDisposed = true;


### PR DESCRIPTION
Backing field for ManualResetEvents prevent synchronization problem on dispose MediaElement. "MediaElement.Dispose" method running in parallel with other operations like RunPacketReadingWorker. Dispose of synchronization objects (like Packet Reading Cycle) may occurs before this operation completed.

