### PR TITLE
Resolve for floating Exception

### DIFF
--- a/Unosquare.FFME.Common/Shared/MediaEngineState.cs
+++ b/Unosquare.FFME.Common/Shared/MediaEngineState.cs
@@ -121,7 +121,7 @@
             {
                 if (IsOpen == false) { return TimeSpan.Zero; }
 
-                if (HasVideo && VideoFrameLength > 0)
+                if (HasVideo && VideoFrameLength > 0 && !double.IsInfinity(VideoFrameLength))
                     return TimeSpan.FromSeconds(VideoFrameLength);
 
                 return TimeSpan.FromSeconds(0.1d);


### PR DESCRIPTION
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.OverflowException: TimeSpan overflowed because the duration is too long.
   at System.TimeSpan.Interval(Double value, Int32 scale)
   at System.TimeSpan.FromSeconds(Double value)
   at Unosquare.FFME.Shared.MediaEngineState.get_FrameStepDuration()
   at Unosquare.FFME.MediaElement.get_FrameStepDuration()
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.RuntimePropertyInfo.GetValue(Object obj, BindingFlags invokeAttr, Binder binder, Object[] index, CultureInfo culture)
   at System.Reflection.RuntimePropertyInfo.GetValue(Object obj, Object[] index)
   at System.Reflection.PropertyInfo.GetValue(Object obj)
   at Unosquare.FFME.Platform.PropertyMapper.SnapshotNotifications(MediaElement m, Dictionary`2 target)
   at Unosquare.FFME.Platform.PropertyMapper.DetectNotificationPropertyChanges(MediaElement m, Dictionary`2 lastSnapshot)
   at Unosquare.FFME.MediaElement.UpdateNotificationProperties()
   at Unosquare.FFME.MediaElement.<StartPropertyUpdatesWorker>b__6_0()
   at Unosquare.FFME.Platform.GuiTimer.RunTimerCycle(Object state)
   at Unosquare.FFME.Platform.GuiTimer.<CreateDispatcherTimer>b__23_0(Object s, EventArgs e)
   at System.Windows.Threading.DispatcherTimer.FireTick(Object unused)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)