### PR TITLE
Update Source property from GuiContext in MediaElement.Open method

### DIFF
--- a/Unosquare.FFME.Windows/MediaElement.cs
+++ b/Unosquare.FFME.Windows/MediaElement.cs
@@ -238,12 +238,12 @@
             try
             {
                 IsOpeningViaCommand.Value = true;
-                Source = uri;
+                GuiContext.Current.Invoke(() => Source = uri);
                 await MediaCore.Open(uri);
             }
             catch (Exception ex)
             {
-                Source = null;
+                GuiContext.Current.Invoke(() => Source = null);
                 RaiseMediaFailedEvent(ex);
                 IsOpeningViaCommand.Value = false;
             }


### PR DESCRIPTION
The Source dependency property should be updated from the UI thread when using the Open() method.