### PR TITLE
Prevent rendering of blocks that were already disposed

### DIFF
--- a/Unosquare.FFME.Common/MediaEngine.Workers.Rendering.cs
+++ b/Unosquare.FFME.Common/MediaEngine.Workers.Rendering.cs
@@ -59,7 +59,7 @@
 
                 if (IsTaskCancellationPending || BlockRenderingWorkerExit.IsCompleted || IsDisposed)
                 {
-                    BlockRenderingWorkerExit.Complete();
+                    BlockRenderingWorkerExit?.Complete();
                     return;
                 }
 
@@ -121,15 +121,12 @@
                     foreach (var t in all)
                     {
                         // Skip rendering for nulls
-                        if (currentBlock[t] == null)
+                        if (currentBlock[t] == null || currentBlock[t].IsDisposed)
                             continue;
 
                         // Render by forced signal (TimeSpan.MinValue) or because simply it is time to do so
                         if (LastRenderTime[t] == TimeSpan.MinValue || currentBlock[t].StartTime != LastRenderTime[t])
-                        {
                             renderedBlockCount[t] += SendBlockToRenderer(currentBlock[t], wallClock);
-                            continue;
-                        }
                     }
 
                     #endregion

--- a/Unosquare.FFME.Common/MediaEngine.Workers.cs
+++ b/Unosquare.FFME.Common/MediaEngine.Workers.cs
@@ -281,7 +281,7 @@
         private int SendBlockToRenderer(MediaBlock block, TimeSpan clockPosition)
         {
             // Process property changes coming from video blocks
-            if (block != null && block.MediaType == MediaType.Video)
+            if (block.MediaType == MediaType.Video)
             {
                 if (block is VideoBlock videoBlock)
                 {

--- a/Unosquare.FFME.Common/Shared/AudioBlock.cs
+++ b/Unosquare.FFME.Common/Shared/AudioBlock.cs
@@ -9,12 +9,6 @@
     /// </summary>
     public sealed class AudioBlock : MediaBlock
     {
-        #region Private Members
-
-        private bool IsDisposed = false; // To detect redundant calls
-
-        #endregion
-
         #region Constructors and Destructors
 
         /// <summary>

--- a/Unosquare.FFME.Common/Shared/MediaBlock.cs
+++ b/Unosquare.FFME.Common/Shared/MediaBlock.cs
@@ -56,6 +56,11 @@
         }
 
         /// <summary>
+        /// Gets a value indicating whether this block is disposed
+        /// </summary>
+        public bool IsDisposed { get; protected set; }
+
+        /// <summary>
         /// Determines whether this media block holds the specified position.
         /// Returns false if it does not have a valid duration.
         /// </summary>

--- a/Unosquare.FFME.Common/Shared/VideoBlock.cs
+++ b/Unosquare.FFME.Common/Shared/VideoBlock.cs
@@ -10,12 +10,6 @@
     /// </summary>
     public sealed class VideoBlock : MediaBlock, IDisposable
     {
-        #region Private Members
-
-        private bool IsDisposed = false; // To detect redundant calls
-
-        #endregion
-
         #region Constructors and Descrutors
 
         /// <summary>

--- a/Unosquare.FFME.Windows/MediaElement.cs
+++ b/Unosquare.FFME.Windows/MediaElement.cs
@@ -238,12 +238,12 @@
             try
             {
                 IsOpeningViaCommand.Value = true;
-                Source = uri;
+                GuiContext.Current.Invoke(() => Source = uri);
                 await MediaCore.Open(uri);
             }
             catch (Exception ex)
             {
-                Source = null;
+                GuiContext.Current.Invoke(() => Source = null);
                 RaiseMediaFailedEvent(ex);
                 IsOpeningViaCommand.Value = false;
             }


### PR DESCRIPTION

`VideoRenderer.LoadTargetBitmapBuffer()` might access already freed buffers of disposed VideoBlocks by calling `WindowsNativeMethods.Instance.CopyMemory` which will in turn throw an System.AccessViolationException.

This change prevents disposed blocks from getting passed to the respective renderers at all.