### PR TITLE
Error handling (partial) when no audio device in system.

### DIFF
--- a/Unosquare.FFME.Windows/Rendering/Wave/WaveInterop.cs
+++ b/Unosquare.FFME.Windows/Rendering/Wave/WaveInterop.cs
@@ -237,11 +237,13 @@
 
             try
             {
-                MmException.Try(
-                    NativeMethods.waveOutOpenWindow(out IntPtr hWaveOut, deviceId, format, callbackWindowHandle, instanceHandle, openFlags),
-                    nameof(NativeMethods.waveOutOpenWindow));
-
-                return hWaveOut;
+				try
+                {
+					MmException.Try(
+						NativeMethods.waveOutOpenWindow(out IntPtr hWaveOut, deviceId, format, callbackWindowHandle, instanceHandle, openFlags),
+						nameof(NativeMethods.waveOutOpenWindow));
+                    return hWaveOut;
+                } catch { return IntPtr.Zero; }
             }
             catch { throw; }
             finally { Monitor.Exit(SyncLock); }


### PR DESCRIPTION
Solution for playing media with audio channel when no any audio device in system (only working with RendererOptions.UseLegacyAudioOut = true).