### PR TITLE
Resolve trouble with "No audio in system"

### DIFF
--- a/Unosquare.FFME.Windows/Rendering/AudioRenderer.cs
+++ b/Unosquare.FFME.Windows/Rendering/AudioRenderer.cs
@@ -26,8 +26,8 @@
         private const int SyncThresholdMaxStep = 25;
         private const int SyncLockTimeout = 100;
 
-        private readonly IWaitEvent WaitForReadyEvent = WaitEventFactory.Create(isCompleted: false, useSlim: true);
         private readonly object SyncLock = new object();
+        private IWaitEvent WaitForReadyEvent = WaitEventFactory.Create(isCompleted: false, useSlim: true);
 
         private IWavePlayer AudioDevice = null;
         private SoundTouch AudioProcessor = null;
@@ -436,6 +436,7 @@
             // Check if we have an audio output device.
             if (hasAudioDevices == false)
             {
+                WaitForReadyEvent = null;
                 MediaCore.Log(MediaLogMessageType.Warning,
                     $"AUDIO OUT: No audio device found for output.");
 


### PR DESCRIPTION
Sets AudioRenderer.WaitForReadyEvent = null when hasAudioDevices == false in AudioRenderer.Initialize. Or program hangs (when all audio devices is off or no any audio devices in system) on Renderers[Audio]?.WaitForReadyState() (MediaEngine.StartBlockRenderingWorker).