### PR TITLE
Calculating subtitle end time

### DIFF
--- a/Unosquare.FFME.Common/Decoding/SubtitleFrame.cs
+++ b/Unosquare.FFME.Common/Decoding/SubtitleFrame.cs
@@ -41,7 +41,6 @@
             EndTime = TimeSpan.FromMilliseconds(timeOffset.TotalMilliseconds + frame->end_display_time);
             Duration = TimeSpan.FromMilliseconds(frame->end_display_time - frame->start_display_time);
 
-
             // Extract text strings
             TextType = AVSubtitleType.SUBTITLE_NONE;
 

--- a/Unosquare.FFME.Common/Decoding/SubtitleFrame.cs
+++ b/Unosquare.FFME.Common/Decoding/SubtitleFrame.cs
@@ -38,7 +38,10 @@
 
             // start_display_time and end_display_time are relative to timeOffset
             StartTime = TimeSpan.FromTicks(timeOffset.Ticks + Convert.ToInt64(frame->start_display_time).ToTimeSpan(StreamTimeBase).Ticks);
-            EndTime = TimeSpan.FromTicks(timeOffset.Ticks + Convert.ToInt64(frame->end_display_time).ToTimeSpan(StreamTimeBase).Ticks);
+
+            // EndTime = TimeSpan.FromTicks(timeOffset.Ticks + Convert.ToInt64(frame->end_display_time).ToTimeSpan(StreamTimeBase).Ticks);
+            EndTime = TimeSpan.FromMilliseconds(timeOffset.TotalMilliseconds + frame->pts.ToTimeSpan().TotalMilliseconds + frame->end_display_time);
+
             Duration = TimeSpan.FromTicks(EndTime.Ticks - StartTime.Ticks);
 
             // Extract text strings

--- a/Unosquare.FFME.Common/Decoding/SubtitleFrame.cs
+++ b/Unosquare.FFME.Common/Decoding/SubtitleFrame.cs
@@ -37,12 +37,10 @@
             var timeOffset = TimeSpan.FromTicks(frame->pts.ToTimeSpan(ffmpeg.AV_TIME_BASE).Ticks - mainOffset.Ticks);
 
             // start_display_time and end_display_time are relative to timeOffset
-            StartTime = TimeSpan.FromTicks(timeOffset.Ticks + Convert.ToInt64(frame->start_display_time).ToTimeSpan(StreamTimeBase).Ticks);
+            StartTime = TimeSpan.FromMilliseconds(timeOffset.TotalMilliseconds + frame->start_display_time);
+            EndTime = TimeSpan.FromMilliseconds(timeOffset.TotalMilliseconds + frame->end_display_time);
+            Duration = TimeSpan.FromMilliseconds(frame->end_display_time - frame->start_display_time);
 
-            // EndTime = TimeSpan.FromTicks(timeOffset.Ticks + Convert.ToInt64(frame->end_display_time).ToTimeSpan(StreamTimeBase).Ticks);
-            EndTime = TimeSpan.FromMilliseconds(timeOffset.TotalMilliseconds + frame->pts.ToTimeSpan().TotalMilliseconds + frame->end_display_time);
-
-            Duration = TimeSpan.FromTicks(EndTime.Ticks - StartTime.Ticks);
 
             // Extract text strings
             TextType = AVSubtitleType.SUBTITLE_NONE;


### PR DESCRIPTION
This gives the proper TimeSpan for the EndTime.

according to the ffmpeg docs:
 3875 typedef struct AVSubtitle {
 3876     uint16_t format; /* 0 = graphics */
 3877     uint32_t start_display_time; /* relative to packet pts, in ms */
 3878     uint32_t end_display_time; /* relative to packet pts, in ms */
 3879     unsigned num_rects;
 3880     AVSubtitleRect **rects;
 3881     int64_t pts;    ///< Same as packet pts, in AV_TIME_BASE
 3882 } AVSubtitle;