### PR TITLE
AudioRenderer Balance bug fix

### DIFF
--- a/Unosquare.FFME.Windows/Rendering/AudioRenderer.cs
+++ b/Unosquare.FFME.Windows/Rendering/AudioRenderer.cs
@@ -834,7 +834,7 @@
 
                 if (isLeftSample && Math.Abs(leftVolume - 1.0) > double.Epsilon)
                     currentSample = Convert.ToInt16(currentSample * leftVolume);
-                else if (isLeftSample == false && Math.Abs(leftVolume - 1.0) > double.Epsilon)
+                else if (isLeftSample == false && Math.Abs(rightVolume - 1.0) > double.Epsilon)
                     currentSample = Convert.ToInt16(currentSample * rightVolume);
 
                 targetBuffer.PutAudioSample(targetBufferOffset + sourceBufferOffset, currentSample);


### PR DESCRIPTION
Audio balance code seems to have a bug: using the Balance slider in WPF Sample worked well when going to Right speaker, but failed to lower the right volume when going to the Left side.
I believe it is a copy-paste error in a single line of code. This modification makes the sample project and my custom projects behave as expected with the limited number of videos files I tested.