### PR TITLE
Allow for disabling pixel aspect ratio scaling

### DIFF
--- a/Unosquare.FFME.Windows/MediaElement.Properties.cs
+++ b/Unosquare.FFME.Windows/MediaElement.Properties.cs
@@ -503,6 +503,29 @@ namespace Unosquare.FFME
         }
 
         #endregion
+
+        #region IgnorePixelAspectRatio Dependency Property
+
+        /// <summary>
+        /// Gets/Sets the stretch direction of the ViewBox, which determines the restrictions on
+        /// scaling that are applied to the content inside the ViewBox.  For instance, this property
+        /// can be used to prevent the content from being smaller than its native size or larger than
+        /// its native size.
+        /// </summary>
+        public bool IgnorePixelAspectRatio
+        {
+            get => (bool)GetValue(IgnorePixelAspectRatioProperty);
+            set => SetValue(IgnorePixelAspectRatioProperty, value);
+        }
+
+        /// <summary>
+        /// DependencyProperty for StretchDirection property.
+        /// </summary>
+        public static readonly DependencyProperty IgnorePixelAspectRatioProperty = DependencyProperty.Register(
+            nameof(IgnorePixelAspectRatio), typeof(bool), typeof(MediaElement),
+            new FrameworkPropertyMetadata(false, AffectsMeasureAndRender));
+
+        #endregion
     }
 }
 #pragma warning restore SA1117 // Parameters must be on same line or separate lines

--- a/Unosquare.FFME.Windows/Rendering/VideoRenderer.cs
+++ b/Unosquare.FFME.Windows/Rendering/VideoRenderer.cs
@@ -378,7 +378,7 @@
                 return;
 
             // Process Aspect Ratio according to block.
-            if (b.PixelAspectWidth != b.PixelAspectHeight)
+            if (b.PixelAspectWidth != b.PixelAspectHeight && MediaElement.IgnorePixelAspectRatio == false)
             {
                 var scaleX = b.PixelAspectWidth > b.PixelAspectHeight ? Convert.ToDouble(b.PixelAspectWidth) / Convert.ToDouble(b.PixelAspectHeight) : 1d;
                 var scaleY = b.PixelAspectHeight > b.PixelAspectWidth ? Convert.ToDouble(b.PixelAspectHeight) / Convert.ToDouble(b.PixelAspectWidth) : 1d;


### PR DESCRIPTION
For our player it is desirable to disable the pixel aspect ratio scaling. This adds a new dependency property to turn off the scaling.