### PR TITLE
Allow for seeking custom streams

### DIFF
--- a/Unosquare.FFME/Container/MediaContainer.cs
+++ b/Unosquare.FFME/Container/MediaContainer.cs
@@ -267,7 +267,7 @@ namespace Unosquare.FFME.Container
         /// <summary>
         /// Gets a value indicating whether the underlying media is seekable.
         /// </summary>
-        public bool IsStreamSeekable => (Components?.PlaybackDuration?.Ticks ?? 0) > 0;
+        public bool IsStreamSeekable => CustomInputStream?.CanSeek ?? (Components?.PlaybackDuration?.Ticks ?? 0) > 0;
 
         /// <summary>
         /// Gets a value indicating whether this container represents live media.


### PR DESCRIPTION
Our media player makes use of custom streams. In our case these streams are within our control and seekable. This enables seeking on those custom streams.