### PR TITLE
Fix of FFmpegLoadMode.MinimumFeatures

### DIFF
--- a/Unosquare.FFME/Container/AudioComponent.cs
+++ b/Unosquare.FFME/Container/AudioComponent.cs
@@ -309,7 +309,14 @@
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void InitializeFilterGraph(AVFrame* frame)
         {
-            // References: https://www.ffmpeg.org/doxygen/2.0/doc_2examples_2filtering_audio_8c-example.html
+            /* References: https://www.ffmpeg.org/doxygen/2.0/doc_2examples_2filtering_audio_8c-example.html */
+
+            if ((Library.FFmpegLoadModeFlags & FFLibrary.LibAVFilter.FlagId) != FFLibrary.LibAVFilter.FlagId)
+            {
+                // Skip FilterGraph initalization if the AVFilter library is not available
+                return;
+            }
+
             const string SourceFilterName = "abuffer";
             const string SourceFilterInstance = "audio_buffer";
             const string SinkFilterName = "abuffersink";

--- a/Unosquare.FFME/Container/VideoComponent.cs
+++ b/Unosquare.FFME/Container/VideoComponent.cs
@@ -346,10 +346,7 @@
             }
 
             // Init the filter graph for the frame
-            if ((Library.FFmpegLoadModeFlags & FFLibrary.LibAVFilter.FlagId) == FFLibrary.LibAVFilter.FlagId)
-            {
-                InitializeFilterGraph(frame);
-            }
+            InitializeFilterGraph(frame);
 
             AVFrame* outputFrame;
 
@@ -525,6 +522,12 @@
              * https://www.ffmpeg.org/doxygen/trunk/filtering_8c-source.html
              * https://raw.githubusercontent.com/FFmpeg/FFmpeg/release/3.2/ffplay.c
              */
+
+            if ((Library.FFmpegLoadModeFlags & FFLibrary.LibAVFilter.FlagId) != FFLibrary.LibAVFilter.FlagId)
+            {
+                // Skip FilterGraph initalization if the AVFilter library is not available
+                return;
+            }
 
             const string SourceFilterName = "buffer";
             const string SourceFilterInstance = "video_buffer";

--- a/Unosquare.FFME/Container/VideoComponent.cs
+++ b/Unosquare.FFME/Container/VideoComponent.cs
@@ -346,7 +346,10 @@
             }
 
             // Init the filter graph for the frame
-            InitializeFilterGraph(frame);
+            if ((Library.FFmpegLoadModeFlags & FFLibrary.LibAVFilter.FlagId) == FFLibrary.LibAVFilter.FlagId)
+            {
+                InitializeFilterGraph(frame);
+            }
 
             AVFrame* outputFrame;
 


### PR DESCRIPTION
Skip FilterGraph initialization when Lib AVFilter is disabled (to avoid forced loading of AVFilter and its dependencies). See #480