### PR TITLE
Fix #576 (Deadlock)

### DIFF
--- a/Unosquare.FFME/Commands/CommandManager.cs
+++ b/Unosquare.FFME/Commands/CommandManager.cs
@@ -12,8 +12,8 @@ namespace Unosquare.FFME.Commands
     using System.Threading.Tasks;
 
     /// <summary>
-    /// Provides the MediEngine with an API to execute media control commands.
-    /// Direct Commands execute immediately (Open, CLose, Change)
+    /// Provides the MediaEngine with an API to execute media control commands.
+    /// Direct Commands execute immediately (Open, Close, Change)
     /// Priority Commands execute in the queue but before anything else and are exclusive (Play, Pause, Stop)
     /// Seek commands are queued and replaced. These are processed in a deferred manner by this worker.
     /// </summary>

--- a/Unosquare.FFME/Primitives/WorkerBase.cs
+++ b/Unosquare.FFME/Primitives/WorkerBase.cs
@@ -101,11 +101,11 @@
         /// <inheritdoc />
         public Task<WorkerState> PauseAsync()
         {
+            // 2021-12-16 Moved this outside of the sync block, to avoid deadlock (#576)
+            if (IsDisposed || IsDisposing)
+                return Task.FromResult(WorkerState);
             lock (SyncLock)
             {
-                if (IsDisposed || IsDisposing)
-                    return Task.FromResult(WorkerState);
-
                 if (WorkerState != WorkerState.Running)
                     return Task.FromResult(WorkerState);
 


### PR DESCRIPTION
Moving IsDisposed || IsDisposing code paths out of lock, to avoid deadlock.