### PR TITLE
remove setting of the seekable field

### DIFF
--- a/Unosquare.FFME.Windows.Sample/MainWindow.MediaEvents.cs
+++ b/Unosquare.FFME.Windows.Sample/MainWindow.MediaEvents.cs
@@ -1,10 +1,9 @@
-﻿using System.Collections.Generic;
-
-namespace Unosquare.FFME.Windows.Sample
+﻿namespace Unosquare.FFME.Windows.Sample
 {
     using ClosedCaptions;
     using FFmpeg.AutoGen;
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
     using System.Linq;

--- a/Unosquare.FFME.Windows.Sample/MainWindow.MediaEvents.cs
+++ b/Unosquare.FFME.Windows.Sample/MainWindow.MediaEvents.cs
@@ -1,4 +1,6 @@
-﻿namespace Unosquare.FFME.Windows.Sample
+﻿using System.Collections.Generic;
+
+namespace Unosquare.FFME.Windows.Sample
 {
     using ClosedCaptions;
     using FFmpeg.AutoGen;
@@ -286,16 +288,16 @@
                 // Hardware device selection
                 if (videoStream.FPS <= 30)
                 {
+                    var devices = new List<HardwareDeviceInfo>(deviceCandidates.Length);
                     foreach (var deviceType in deviceCandidates)
                     {
                         var accelerator = videoStream.HardwareDevices.FirstOrDefault(d => d.DeviceType == deviceType);
                         if (accelerator == null) continue;
 
-                        if (Debugger.IsAttached)
-                            e.Options.VideoHardwareDevice = accelerator;
-
-                        break;
+                        devices.Add(accelerator);
                     }
+
+                    e.Options.VideoHardwareDevices = devices.ToArray();
                 }
 
                 // Start building a video filter

--- a/Unosquare.FFME/Common/MediaOptions.cs
+++ b/Unosquare.FFME/Common/MediaOptions.cs
@@ -43,7 +43,7 @@
         /// Use Stream's HardwareDevices property to get a list of
         /// compatible hardware accelerators.
         /// </summary>
-        public HardwareDeviceInfo VideoHardwareDevice { get; set; }
+        public HardwareDeviceInfo[] VideoHardwareDevices { get; set; }
 
         /// <summary>
         /// Prevent reading from audio stream components.

--- a/Unosquare.FFME/Container/MediaComponent.cs
+++ b/Unosquare.FFME/Container/MediaComponent.cs
@@ -167,7 +167,7 @@
                 codecOptions.SetCopyOpaque();
 
                 // Enable Hardware acceleration if requested
-                (this as VideoComponent)?.AttachHardwareDevice(container.MediaOptions.VideoHardwareDevice);
+                (this as VideoComponent)?.AttachHardwareDevice(container.MediaOptions.VideoHardwareDevices);
 
                 // Open the CodecContext. This requires exclusive FFmpeg access
                 lock (CodecLock)

--- a/Unosquare.FFME/Container/MediaContainer.cs
+++ b/Unosquare.FFME/Container/MediaContainer.cs
@@ -682,9 +682,6 @@ internal sealed unsafe class MediaContainer : IDisposable, ILoggingSource
                     CustomInputStreamContext = ffmpeg.avio_alloc_context(
                         inputBuffer, CustomInputStream.ReadBufferLength, 0, null, CustomInputStreamRead, null, CustomInputStreamSeek);
 
-                    // Set the seekable flag based on the custom input stream implementation
-                    CustomInputStreamContext->seekable = CustomInputStream.CanSeek ? ffmpeg.AVIO_SEEKABLE_NORMAL : 0;
-
                     // Assign the AVIOContext to the input context
                     inputContextPtr->pb = CustomInputStreamContext;
                 }


### PR DESCRIPTION
remove setting of the seekable field, since it causes access violation errors, and unnecessary.

Check the comment from june 6, 2023: https://github.com/unosquare/ffmediaelement/issues/642

Or:
https://github.com/Ruslan-B/FFmpeg.AutoGen/issues/255

Currently I'm using my own package, but I'd like to swicth your original version, but this issue block me.

Reproduce the issue: Just open any local video file with the following url: customfile://C:\myfolder\myfile.mkv
It will use the FileInputStream which sets the seekable field. => access violation when trying to open the media.